### PR TITLE
Declaración de propiedades de forma explícita en la clase

### DIFF
--- a/includes/filter-by-cities.php
+++ b/includes/filter-by-cities.php
@@ -6,8 +6,9 @@
  * Time: 05:32 PM
  */
 
- function filters_by_cities_method() {
-    if ( ! class_exists( 'Filters_By_Cities_Method' ) ) {
+function filters_by_cities_method()
+{
+    if (!class_exists('Filters_By_Cities_Method')) {
 
         class Filters_By_Cities_Method extends WC_Shipping_Method
         {
@@ -30,10 +31,10 @@
             {
                 parent::__construct($instance_id);
 
-                $this->id                 = 'filters_by_cities_shipping_method';
-                $this->instance_id        = absint( $instance_id );
-                $this->method_title       = __( 'Shipping filter By Cities', 'departamentos-y-ciudades-de-colombia-para-woocommerce' );
-                $this->method_description = __( 'Allows adding rules by city', 'departamentos-y-ciudades-de-colombia-para-woocommerce' );
+                $this->id = 'filters_by_cities_shipping_method';
+                $this->instance_id = absint($instance_id);
+                $this->method_title = __('Shipping filter By Cities', 'departamentos-y-ciudades-de-colombia-para-woocommerce');
+                $this->method_description = __('Allows adding rules by city', 'departamentos-y-ciudades-de-colombia-para-woocommerce');
 
                 $this->supports = array(
                     'settings',
@@ -50,22 +51,23 @@
              * @access public
              * @return void
              */
-            function init() {
+            function init()
+            {
                 // Load the settings API
                 $this->instance_form_fields = $this->define_instance_form_fields();
                 $this->form_fields = $this->define_global_form_fields();
                 $this->single_method = $this->get_option('single_method');
                 $this->title = $this->get_option('title');
-                $this->tax_status = $this->get_option( 'tax_status' );
-                $this->cost = $this->get_option( 'cost' );
-                $this->cities = $this->get_option( 'cities' );
-                $this->type = $this->get_option( 'type', 'class' );
+                $this->tax_status = $this->get_option('tax_status');
+                $this->cost = $this->get_option('cost');
+                $this->cities = $this->get_option('cities');
+                $this->type = $this->get_option('type', 'class');
 
                 $this->init_form_fields();
                 $this->init_settings();
 
                 // Save settings in admin if you have any defined
-                add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
+                add_action('woocommerce_update_options_shipping_' . $this->id, array($this, 'process_admin_options'));
             }
 
 
@@ -103,12 +105,12 @@
              * @param mixed $package
              * @return void
              */
-            public function calculate_shipping( $package = array() )
+            public function calculate_shipping($package = array())
             {
-                $params_rate =array(
+                $params_rate = array(
                     'id' => $this->id,
-                    'label'   => $this->title,
-                    'cost'		=> 0,
+                    'label' => $this->title,
+                    'cost' => 0,
                     'package' => $package,
                 );
 
@@ -116,48 +118,50 @@
 
                 // Calculate the costs.
                 $has_costs = false; // True when a cost is set. False if all costs are blank strings.
-                $cost = $this->get_option( 'cost' );
-                if ( '' !== $cost ) {
-                    $has_costs    = true;
+                $cost = $this->get_option('cost');
+                if ('' !== $cost) {
+                    $has_costs = true;
                     $rate['cost'] = $this->evaluate_cost(
-                        $cost, array(
-                            'qty'  => $this->get_package_item_qty( $package ),
+                        $cost,
+                        array(
+                            'qty' => $this->get_package_item_qty($package),
                             'cost' => $package['contents_cost'],
                         )
                     );
                 }
                 // Add shipping class costs.
                 $shipping_classes = WC()->shipping->get_shipping_classes();
-                if ( ! empty( $shipping_classes ) ) {
-                    $found_shipping_classes = $this->find_shipping_classes( $package );
-                    $highest_class_cost     = 0;
-                    foreach ( $found_shipping_classes as $shipping_class => $products ) {
+                if (!empty($shipping_classes)) {
+                    $found_shipping_classes = $this->find_shipping_classes($package);
+                    $highest_class_cost = 0;
+                    foreach ($found_shipping_classes as $shipping_class => $products) {
                         // Also handles BW compatibility when slugs were used instead of ids.
-                        $shipping_class_term = get_term_by( 'slug', $shipping_class, 'product_shipping_class' );
-                        $class_cost_string   = $shipping_class_term && $shipping_class_term->term_id ? $this->get_option( 'class_cost_' . $shipping_class_term->term_id, $this->get_option( 'class_cost_' . $shipping_class, '' ) ) : $this->get_option( 'no_class_cost', '' );
-                        if ( '' === $class_cost_string ) {
+                        $shipping_class_term = get_term_by('slug', $shipping_class, 'product_shipping_class');
+                        $class_cost_string = $shipping_class_term && $shipping_class_term->term_id ? $this->get_option('class_cost_' . $shipping_class_term->term_id, $this->get_option('class_cost_' . $shipping_class, '')) : $this->get_option('no_class_cost', '');
+                        if ('' === $class_cost_string) {
                             continue;
                         }
-                        $has_costs  = true;
+                        $has_costs = true;
                         $class_cost = $this->evaluate_cost(
-                            $class_cost_string, array(
-                                'qty'  => array_sum( wp_list_pluck( $products, 'quantity' ) ),
-                                'cost' => array_sum( wp_list_pluck( $products, 'line_total' ) ),
+                            $class_cost_string,
+                            array(
+                                'qty' => array_sum(wp_list_pluck($products, 'quantity')),
+                                'cost' => array_sum(wp_list_pluck($products, 'line_total')),
                             )
                         );
-                        if ( 'class' === $this->type ) {
-                            $rate['cost'] += $class_cost * array_sum( wp_list_pluck( $products, 'quantity' ) );
+                        if ('class' === $this->type) {
+                            $rate['cost'] += $class_cost * array_sum(wp_list_pluck($products, 'quantity'));
                         } else {
                             $highest_class_cost = $class_cost > $highest_class_cost ? $class_cost : $highest_class_cost;
                         }
                     }
-                    if ( 'order' === $this->type && $highest_class_cost ) {
+                    if ('order' === $this->type && $highest_class_cost) {
                         $rate['cost'] += $highest_class_cost;
                     }
                 }
 
-                if ( $has_costs ) {
-                    $this->add_rate( $rate );
+                if ($has_costs) {
+                    $this->add_rate($rate);
                 }
             }
 
@@ -167,24 +171,24 @@
              * @param array $package Package information.
              * @return bool
              */
-            public function is_available( $package )
+            public function is_available($package)
             {
                 $city_destination = $package['destination']['city'];
 
-                if (!empty($this->cities)){
+                if (!empty($this->cities)) {
                     if (!in_array($city_destination, $this->cities))
-                        return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', false, $package, $this );
+                        return apply_filters('woocommerce_shipping_' . $this->id . '_is_available', false, $package, $this);
                     if ($this->single_method === 'yes')
-                    add_filter( 'woocommerce_package_rates', array($this, 'unset_filters_by_cities_shipping_method_zones') , 10, 2 );
+                        add_filter('woocommerce_package_rates', array($this, 'unset_filters_by_cities_shipping_method_zones'), 10, 2);
                 }
-                return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', true, $package, $this );
+                return apply_filters('woocommerce_shipping_' . $this->id . '_is_available', true, $package, $this);
             }
 
             public function show_cities_regions()
             {
                 if (!isset($_REQUEST['instance_id']))
                     return array();
-                $ins = WC_Shipping_Zones::get_zone_by( 'instance_id', $_REQUEST['instance_id'] );
+                $ins = WC_Shipping_Zones::get_zone_by('instance_id', $_REQUEST['instance_id']);
                 $data = $ins->get_data();
                 if (!isset($data['zone_locations']))
                     return array();
@@ -192,11 +196,11 @@
 
                 $cities = array();
 
-                foreach ($zones as $zone){
-                    if (str_contains($zone->code, ':')){
-                        $place = explode(':', $zone->code );
-                        $states = WC_States_Places_Colombia::get_places( $place[0] );
-                        $cities =  array_merge($cities,$this->orderArray($states[$place[1]]));
+                foreach ($zones as $zone) {
+                    if (str_contains($zone->code, ':')) {
+                        $place = explode(':', $zone->code);
+                        $states = WC_States_Places_Colombia::get_places($place[0]);
+                        $cities = array_merge($cities, $this->orderArray($states[$place[1]]));
                     }
                 }
 
@@ -206,14 +210,14 @@
             public function unset_filters_by_cities_shipping_method_zones($rates, $package)
             {
                 $all_free_rates = array();
-                foreach ( $rates as $rate_id => $rate ) {
-                    if ( $this->id === $rate->method_id ) {
-                        $all_free_rates[ $rate_id ] = $rate;
+                foreach ($rates as $rate_id => $rate) {
+                    if ($this->id === $rate->method_id) {
+                        $all_free_rates[$rate_id] = $rate;
                         break;
                     }
                 }
 
-                return empty( $all_free_rates ) ? $rates : $all_free_rates;
+                return empty($all_free_rates) ? $rates : $all_free_rates;
             }
 
 
@@ -221,7 +225,7 @@
             {
                 $cities = array();
 
-                foreach ($array as $arr){
+                foreach ($array as $arr) {
                     $cities[$arr] = $arr;
                 }
 
@@ -234,16 +238,16 @@
              * @param mixed $package Package of items from cart.
              * @return array
              */
-            public function find_shipping_classes( $package )
+            public function find_shipping_classes($package)
             {
                 $found_shipping_classes = array();
-                foreach ( $package['contents'] as $item_id => $values ) {
-                    if ( $values['data']->needs_shipping() ) {
+                foreach ($package['contents'] as $item_id => $values) {
+                    if ($values['data']->needs_shipping()) {
                         $found_class = $values['data']->get_shipping_class();
-                        if ( ! isset( $found_shipping_classes[ $found_class ] ) ) {
-                            $found_shipping_classes[ $found_class ] = array();
+                        if (!isset($found_shipping_classes[$found_class])) {
+                            $found_shipping_classes[$found_class] = array();
                         }
-                        $found_shipping_classes[ $found_class ][ $item_id ] = $values;
+                        $found_shipping_classes[$found_class][$item_id] = $values;
                     }
                 }
                 return $found_shipping_classes;
@@ -256,16 +260,16 @@
              * @param  array  $args Args.
              * @return string
              */
-            protected function evaluate_cost( $sum, $args = array() )
+            protected function evaluate_cost($sum, $args = array())
             {
                 include_once WC()->plugin_path() . '/includes/libraries/class-wc-eval-math.php';
                 // Allow 3rd parties to process shipping cost arguments.
-                $args           = apply_filters( 'woocommerce_evaluate_shipping_cost_args', $args, $sum, $this );
-                $locale         = localeconv();
-                $decimals       = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'], ',' );
+                $args = apply_filters('woocommerce_evaluate_shipping_cost_args', $args, $sum, $this);
+                $locale = localeconv();
+                $decimals = array(wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'], ',');
                 $this->fee_cost = $args['cost'];
                 // Expand shortcodes.
-                add_shortcode( 'fee', array( $this, 'fee' ) );
+                add_shortcode('fee', array($this, 'fee'));
                 $sum = do_shortcode(
                     str_replace(
                         array(
@@ -279,15 +283,15 @@
                         $sum
                     )
                 );
-                remove_shortcode( 'fee' );
+                remove_shortcode('fee');
                 // Remove whitespace from string.
-                $sum = preg_replace( '/\s+/', '', $sum );
+                $sum = preg_replace('/\s+/', '', $sum);
                 // Remove locale from string.
-                $sum = str_replace( $decimals, '.', $sum );
+                $sum = str_replace($decimals, '.', $sum);
                 // Trim invalid start/end characters.
-                $sum = rtrim( ltrim( $sum, "\t\n\r\0\x0B+*/" ), "\t\n\r\0\x0B+-*/" );
+                $sum = rtrim(ltrim($sum, "\t\n\r\0\x0B+*/"), "\t\n\r\0\x0B+-*/");
                 // Do the math.
-                return $sum ? WC_Eval_Math::evaluate( $sum ) : 0;
+                return $sum ? WC_Eval_Math::evaluate($sum) : 0;
             }
 
             /**
@@ -296,10 +300,11 @@
              * @param  array $package Package of items from cart.
              * @return int
              */
-            public function get_package_item_qty( $package ) {
+            public function get_package_item_qty($package)
+            {
                 $total_quantity = 0;
-                foreach ( $package['contents'] as $item_id => $values ) {
-                    if ( $values['quantity'] > 0 && $values['data']->needs_shipping() ) {
+                foreach ($package['contents'] as $item_id => $values) {
+                    if ($values['quantity'] > 0 && $values['data']->needs_shipping()) {
                         $total_quantity += $values['quantity'];
                     }
                 }

--- a/includes/filter-by-cities.php
+++ b/includes/filter-by-cities.php
@@ -6,9 +6,8 @@
  * Time: 05:32 PM
  */
 
-function filters_by_cities_method()
-{
-    if (!class_exists('Filters_By_Cities_Method')) {
+function filters_by_cities_method() {
+    if ( ! class_exists( 'Filters_By_Cities_Method' ) ) {
 
         class Filters_By_Cities_Method extends WC_Shipping_Method
         {
@@ -31,10 +30,10 @@ function filters_by_cities_method()
             {
                 parent::__construct($instance_id);
 
-                $this->id = 'filters_by_cities_shipping_method';
-                $this->instance_id = absint($instance_id);
-                $this->method_title = __('Shipping filter By Cities', 'departamentos-y-ciudades-de-colombia-para-woocommerce');
-                $this->method_description = __('Allows adding rules by city', 'departamentos-y-ciudades-de-colombia-para-woocommerce');
+                $this->id                 = 'filters_by_cities_shipping_method';
+                $this->instance_id				= absint( $instance_id );
+                $this->method_title       = __( 'Shipping filter By Cities', 'departamentos-y-ciudades-de-colombia-para-woocommerce' );
+                $this->method_description = __( 'Allows adding rules by city', 'departamentos-y-ciudades-de-colombia-para-woocommerce' );
 
                 $this->supports = array(
                     'settings',
@@ -51,23 +50,23 @@ function filters_by_cities_method()
              * @access public
              * @return void
              */
-            function init()
-            {
+            function init() {
                 // Load the settings API
                 $this->instance_form_fields = $this->define_instance_form_fields();
                 $this->form_fields = $this->define_global_form_fields();
                 $this->single_method = $this->get_option('single_method');
                 $this->title = $this->get_option('title');
-                $this->tax_status = $this->get_option('tax_status');
-                $this->cost = $this->get_option('cost');
-                $this->cities = $this->get_option('cities');
-                $this->type = $this->get_option('type', 'class');
+                $this->tax_status = $this->get_option( 'tax_status' );
+                $this->cost = $this->get_option( 'cost' );
+                $this->cities = $this->get_option( 'cities' );
+                $this->type = $this->get_option( 'type', 'class' );
+
 
                 $this->init_form_fields();
                 $this->init_settings();
 
                 // Save settings in admin if you have any defined
-                add_action('woocommerce_update_options_shipping_' . $this->id, array($this, 'process_admin_options'));
+                add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
             }
 
 
@@ -105,12 +104,12 @@ function filters_by_cities_method()
              * @param mixed $package
              * @return void
              */
-            public function calculate_shipping($package = array())
+            public function calculate_shipping( $package = array() )
             {
-                $params_rate = array(
+                $params_rate =array(
                     'id' => $this->id,
-                    'label' => $this->title,
-                    'cost' => 0,
+                    'label'   => $this->title,
+                    'cost'		=> 0,
                     'package' => $package,
                 );
 
@@ -118,50 +117,48 @@ function filters_by_cities_method()
 
                 // Calculate the costs.
                 $has_costs = false; // True when a cost is set. False if all costs are blank strings.
-                $cost = $this->get_option('cost');
-                if ('' !== $cost) {
-                    $has_costs = true;
+                $cost = $this->get_option( 'cost' );
+                if ( '' !== $cost ) {
+                    $has_costs    = true;
                     $rate['cost'] = $this->evaluate_cost(
-                        $cost,
-                        array(
-                            'qty' => $this->get_package_item_qty($package),
+                        $cost, array(
+                            'qty'  => $this->get_package_item_qty( $package ),
                             'cost' => $package['contents_cost'],
                         )
                     );
                 }
                 // Add shipping class costs.
                 $shipping_classes = WC()->shipping->get_shipping_classes();
-                if (!empty($shipping_classes)) {
-                    $found_shipping_classes = $this->find_shipping_classes($package);
-                    $highest_class_cost = 0;
-                    foreach ($found_shipping_classes as $shipping_class => $products) {
+                if ( ! empty( $shipping_classes ) ) {
+                    $found_shipping_classes = $this->find_shipping_classes( $package );
+                    $highest_class_cost     = 0;
+                    foreach ( $found_shipping_classes as $shipping_class => $products ) {
                         // Also handles BW compatibility when slugs were used instead of ids.
-                        $shipping_class_term = get_term_by('slug', $shipping_class, 'product_shipping_class');
-                        $class_cost_string = $shipping_class_term && $shipping_class_term->term_id ? $this->get_option('class_cost_' . $shipping_class_term->term_id, $this->get_option('class_cost_' . $shipping_class, '')) : $this->get_option('no_class_cost', '');
-                        if ('' === $class_cost_string) {
+                        $shipping_class_term = get_term_by( 'slug', $shipping_class, 'product_shipping_class' );
+                        $class_cost_string   = $shipping_class_term && $shipping_class_term->term_id ? $this->get_option( 'class_cost_' . $shipping_class_term->term_id, $this->get_option( 'class_cost_' . $shipping_class, '' ) ) : $this->get_option( 'no_class_cost', '' );
+                        if ( '' === $class_cost_string ) {
                             continue;
                         }
-                        $has_costs = true;
+                        $has_costs  = true;
                         $class_cost = $this->evaluate_cost(
-                            $class_cost_string,
-                            array(
-                                'qty' => array_sum(wp_list_pluck($products, 'quantity')),
-                                'cost' => array_sum(wp_list_pluck($products, 'line_total')),
+                            $class_cost_string, array(
+                                'qty'  => array_sum( wp_list_pluck( $products, 'quantity' ) ),
+                                'cost' => array_sum( wp_list_pluck( $products, 'line_total' ) ),
                             )
                         );
-                        if ('class' === $this->type) {
-                            $rate['cost'] += $class_cost * array_sum(wp_list_pluck($products, 'quantity'));
+                        if ( 'class' === $this->type ) {
+                            $rate['cost'] += $class_cost * array_sum( wp_list_pluck( $products, 'quantity' ) );
                         } else {
                             $highest_class_cost = $class_cost > $highest_class_cost ? $class_cost : $highest_class_cost;
                         }
                     }
-                    if ('order' === $this->type && $highest_class_cost) {
+                    if ( 'order' === $this->type && $highest_class_cost ) {
                         $rate['cost'] += $highest_class_cost;
                     }
                 }
 
-                if ($has_costs) {
-                    $this->add_rate($rate);
+                if ( $has_costs ) {
+                    $this->add_rate( $rate );
                 }
             }
 
@@ -171,24 +168,24 @@ function filters_by_cities_method()
              * @param array $package Package information.
              * @return bool
              */
-            public function is_available($package)
+            public function is_available( $package )
             {
                 $city_destination = $package['destination']['city'];
 
-                if (!empty($this->cities)) {
+                if (!empty($this->cities)){
                     if (!in_array($city_destination, $this->cities))
-                        return apply_filters('woocommerce_shipping_' . $this->id . '_is_available', false, $package, $this);
+                        return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', false, $package, $this );
                     if ($this->single_method === 'yes')
-                        add_filter('woocommerce_package_rates', array($this, 'unset_filters_by_cities_shipping_method_zones'), 10, 2);
+                    add_filter( 'woocommerce_package_rates', array($this, 'unset_filters_by_cities_shipping_method_zones') , 10, 2 );
                 }
-                return apply_filters('woocommerce_shipping_' . $this->id . '_is_available', true, $package, $this);
+                return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', true, $package, $this );
             }
 
             public function show_cities_regions()
             {
                 if (!isset($_REQUEST['instance_id']))
                     return array();
-                $ins = WC_Shipping_Zones::get_zone_by('instance_id', $_REQUEST['instance_id']);
+                $ins = WC_Shipping_Zones::get_zone_by( 'instance_id', $_REQUEST['instance_id'] );
                 $data = $ins->get_data();
                 if (!isset($data['zone_locations']))
                     return array();
@@ -196,11 +193,11 @@ function filters_by_cities_method()
 
                 $cities = array();
 
-                foreach ($zones as $zone) {
-                    if (str_contains($zone->code, ':')) {
-                        $place = explode(':', $zone->code);
-                        $states = WC_States_Places_Colombia::get_places($place[0]);
-                        $cities = array_merge($cities, $this->orderArray($states[$place[1]]));
+                foreach ($zones as $zone){
+                    if (str_contains($zone->code, ':')){
+                        $place = explode(':', $zone->code );
+                        $states = WC_States_Places_Colombia::get_places( $place[0] );
+                        $cities =  array_merge($cities,$this->orderArray($states[$place[1]]));
                     }
                 }
 
@@ -210,14 +207,14 @@ function filters_by_cities_method()
             public function unset_filters_by_cities_shipping_method_zones($rates, $package)
             {
                 $all_free_rates = array();
-                foreach ($rates as $rate_id => $rate) {
-                    if ($this->id === $rate->method_id) {
-                        $all_free_rates[$rate_id] = $rate;
+                foreach ( $rates as $rate_id => $rate ) {
+                    if ( $this->id === $rate->method_id ) {
+                        $all_free_rates[ $rate_id ] = $rate;
                         break;
                     }
                 }
 
-                return empty($all_free_rates) ? $rates : $all_free_rates;
+                return empty( $all_free_rates ) ? $rates : $all_free_rates;
             }
 
 
@@ -225,7 +222,7 @@ function filters_by_cities_method()
             {
                 $cities = array();
 
-                foreach ($array as $arr) {
+                foreach ($array as $arr){
                     $cities[$arr] = $arr;
                 }
 
@@ -238,16 +235,16 @@ function filters_by_cities_method()
              * @param mixed $package Package of items from cart.
              * @return array
              */
-            public function find_shipping_classes($package)
+            public function find_shipping_classes( $package )
             {
                 $found_shipping_classes = array();
-                foreach ($package['contents'] as $item_id => $values) {
-                    if ($values['data']->needs_shipping()) {
+                foreach ( $package['contents'] as $item_id => $values ) {
+                    if ( $values['data']->needs_shipping() ) {
                         $found_class = $values['data']->get_shipping_class();
-                        if (!isset($found_shipping_classes[$found_class])) {
-                            $found_shipping_classes[$found_class] = array();
+                        if ( ! isset( $found_shipping_classes[ $found_class ] ) ) {
+                            $found_shipping_classes[ $found_class ] = array();
                         }
-                        $found_shipping_classes[$found_class][$item_id] = $values;
+                        $found_shipping_classes[ $found_class ][ $item_id ] = $values;
                     }
                 }
                 return $found_shipping_classes;
@@ -260,16 +257,16 @@ function filters_by_cities_method()
              * @param  array  $args Args.
              * @return string
              */
-            protected function evaluate_cost($sum, $args = array())
+            protected function evaluate_cost( $sum, $args = array() )
             {
                 include_once WC()->plugin_path() . '/includes/libraries/class-wc-eval-math.php';
                 // Allow 3rd parties to process shipping cost arguments.
-                $args = apply_filters('woocommerce_evaluate_shipping_cost_args', $args, $sum, $this);
-                $locale = localeconv();
-                $decimals = array(wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'], ',');
+                $args           = apply_filters( 'woocommerce_evaluate_shipping_cost_args', $args, $sum, $this );
+                $locale         = localeconv();
+                $decimals       = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'], ',' );
                 $this->fee_cost = $args['cost'];
                 // Expand shortcodes.
-                add_shortcode('fee', array($this, 'fee'));
+                add_shortcode( 'fee', array( $this, 'fee' ) );
                 $sum = do_shortcode(
                     str_replace(
                         array(
@@ -283,15 +280,15 @@ function filters_by_cities_method()
                         $sum
                     )
                 );
-                remove_shortcode('fee');
+                remove_shortcode( 'fee' );
                 // Remove whitespace from string.
-                $sum = preg_replace('/\s+/', '', $sum);
+                $sum = preg_replace( '/\s+/', '', $sum );
                 // Remove locale from string.
-                $sum = str_replace($decimals, '.', $sum);
+                $sum = str_replace( $decimals, '.', $sum );
                 // Trim invalid start/end characters.
-                $sum = rtrim(ltrim($sum, "\t\n\r\0\x0B+*/"), "\t\n\r\0\x0B+-*/");
+                $sum = rtrim( ltrim( $sum, "\t\n\r\0\x0B+*/" ), "\t\n\r\0\x0B+-*/" );
                 // Do the math.
-                return $sum ? WC_Eval_Math::evaluate($sum) : 0;
+                return $sum ? WC_Eval_Math::evaluate( $sum ) : 0;
             }
 
             /**
@@ -300,11 +297,10 @@ function filters_by_cities_method()
              * @param  array $package Package of items from cart.
              * @return int
              */
-            public function get_package_item_qty($package)
-            {
+            public function get_package_item_qty( $package ) {
                 $total_quantity = 0;
-                foreach ($package['contents'] as $item_id => $values) {
-                    if ($values['quantity'] > 0 && $values['data']->needs_shipping()) {
+                foreach ( $package['contents'] as $item_id => $values ) {
+                    if ( $values['quantity'] > 0 && $values['data']->needs_shipping() ) {
                         $total_quantity += $values['quantity'];
                     }
                 }

--- a/includes/filter-by-cities.php
+++ b/includes/filter-by-cities.php
@@ -6,11 +6,19 @@
  * Time: 05:32 PM
  */
 
-function filters_by_cities_method() {
+ function filters_by_cities_method() {
     if ( ! class_exists( 'Filters_By_Cities_Method' ) ) {
 
         class Filters_By_Cities_Method extends WC_Shipping_Method
         {
+            /**
+             * Class properties declaration
+             */
+            protected $single_method;
+            protected $cost;
+            protected $cities;
+            protected $type;
+            protected $fee_cost;
 
             /**
              * Constructor for your shipping class
@@ -20,11 +28,10 @@ function filters_by_cities_method() {
              */
             public function __construct($instance_id = 0)
             {
-
                 parent::__construct($instance_id);
 
                 $this->id                 = 'filters_by_cities_shipping_method';
-                $this->instance_id				= absint( $instance_id );
+                $this->instance_id        = absint( $instance_id );
                 $this->method_title       = __( 'Shipping filter By Cities', 'departamentos-y-ciudades-de-colombia-para-woocommerce' );
                 $this->method_description = __( 'Allows adding rules by city', 'departamentos-y-ciudades-de-colombia-para-woocommerce' );
 
@@ -53,7 +60,6 @@ function filters_by_cities_method() {
                 $this->cost = $this->get_option( 'cost' );
                 $this->cities = $this->get_option( 'cities' );
                 $this->type = $this->get_option( 'type', 'class' );
-
 
                 $this->init_form_fields();
                 $this->init_settings();


### PR DESCRIPTION
Debido a que la creación dinámica de propiedades de una clase está obsoleta para versiónes superiores a PHP 8.2, se necesita declarar estas propiedades de forma explícita